### PR TITLE
zenfone3: update maintainer

### DIFF
--- a/device_maintainers_fragment.xml
+++ b/device_maintainers_fragment.xml
@@ -1369,13 +1369,6 @@
             app:type="phone" />
 
         <com.android.settings.rr.Preferences.DevicePreference
-            android:id="@+id/device_z012d"
-            android:title="@string/device_z012d"
-            app:codename="@string/device_z012d_codename"
-            app:maintainer="@string/device_z012d_maintainer"
-            app:type="phone" />
-
-        <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_z00a"
             android:title="@string/device_z00a"
             app:codename="@string/device_z00a_codename"

--- a/resurrection_device_maintainers_strings.xml
+++ b/resurrection_device_maintainers_strings.xml
@@ -328,7 +328,7 @@
   <string name="device_fortuna3g_codename" translatable="false">SM-G530H</string>
   <string name="device_fortuna3g_maintainer" translatable="false">Hassan Sardar</string>
    
-  <string name="device_zenfone3" translatable="false">Zenfone 3</string>
+  <string name="device_zenfone3" translatable="false">Asus Zenfone 3</string>
   <string name="device_zenfone3_codename" translatable="false">ZE520KL/ZE552KL</string>
   <string name="device_zenfone3_maintainer" translatable="false">Abhay Kshatriya (vegeto1806)</string> 
 

--- a/resurrection_device_maintainers_strings.xml
+++ b/resurrection_device_maintainers_strings.xml
@@ -840,10 +840,6 @@
   <string name="device_huashan_codename" translatable="false">Huashan</string>
   <string name="device_huashan_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_z012d" translatable="false">Asus Zenfone 3</string>
-  <string name="device_z012d_codename" translatable="false">Z012D</string>
-  <string name="device_z012d_maintainer" translatable="false">Ezio (TurkDevs)</string>
-
   <string name="device_z00a" translatable="false">Asus Zenfone 2</string>
   <string name="device_z00a_codename" translatable="false">Z00A</string>
   <string name="device_z00a_maintainer" translatable="false">sayeed99</string>


### PR DESCRIPTION
Z012D and Z017D are unified as codename zenfone3, so remove older entry (currently shows two Zenfone 3 maintainers..)